### PR TITLE
Tests and refactoring in login-service.js

### DIFF
--- a/test/spec/login-service.js
+++ b/test/spec/login-service.js
@@ -167,7 +167,7 @@ describe('Provider: login-service', function() {
 
   describe('authInterceptor', function () {
 
-    it('should add jwt header to requests when authenticated', inject(function ($http, $httpBackend) {
+    it('should add token to http header to requests when authenticated', inject(function ($http, $httpBackend) {
       var user = {token: 'supersecret'};
 
       $httpBackend.expectGET('/checkheaders', function (headers) {
@@ -186,7 +186,7 @@ describe('Provider: login-service', function() {
       $httpBackend.flush();
     }));
 
-    it('should NOT add jwt header to requests when NOT authenticated', inject(function ($http, $httpBackend) {
+    it('should NOT add token to http header to requests when NOT authenticated', inject(function ($http, $httpBackend) {
 
       $httpBackend.expectGET('/checkheaders', function (headers) {
         expect(headers).not.toContain('X-Token');

--- a/test/spec/login-service.js
+++ b/test/spec/login-service.js
@@ -164,4 +164,40 @@ describe('Provider: login-service', function() {
       expect(loginService.logoutUser).toHaveBeenCalled();
     }));
   });
+
+  describe('authInterceptor', function () {
+
+    it('should add jwt header to requests when authenticated', inject(function ($http, $httpBackend) {
+      var user = {token: 'supersecret'};
+
+      $httpBackend.expectGET('/checkheaders', function (headers) {
+        expect(headers['X-Token']).toEqual(user.token);
+
+        return true;//Have to return true to match the headers
+      }).respond(200);
+
+      //login should set headers
+      loginService.loginHandler(user);
+
+      //Make request which httpBackend will intercept and set the expectation
+      $http.get('/checkheaders');
+
+      //Flush triggers the intercept and resolves the $http promise
+      $httpBackend.flush();
+    }));
+
+    it('should NOT add jwt header to requests when NOT authenticated', inject(function ($http, $httpBackend) {
+
+      $httpBackend.expectGET('/checkheaders', function (headers) {
+        expect(headers).not.toContain('X-Token');
+        return true;//Have to return true to match the headers
+      }).respond(200);
+
+      //Make request which httpBackend will intercept and set the expectation
+      $http.get('/checkheaders');
+
+      //Flush triggers the intercept and resolves the $http promise
+      $httpBackend.flush();
+    }));
+  });
 });


### PR DESCRIPTION
I've added some tests for managePermissions, the synchronous permission checks triggered when ui-router attempts to change state (and broadcasts the change / error)
